### PR TITLE
Fix path to diff-check in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,7 @@ runs:
     - run: ${{ inputs.command }}
       shell: bash
 
-    - name: Add Action to $GITHUB_PATH
-      run: echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+    - run: $GITHUB_ACTION_PATH/bin/diff-check >> $GITHUB_STEP_SUMMARY
       shell: bash
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
-
-    - run: bin/diff-check >> $GITHUB_STEP_SUMMARY
-      shell: bash


### PR DESCRIPTION
It was previously assumed that `$GITHUB_PATH` affected the `$PATH` lookup but this wasn't actually the case and so the command could never be run.

Instead, this uses `$GITHUB_ACTION_PATH` (which is the path to the action cached on the runner) to built out a full path for `diff-check` instead, which is also simpler.

Fixes #4.