### PR TITLE
Add backticks to format file names as code

### DIFF
--- a/bin/diff-check
+++ b/bin/diff-check
@@ -6,7 +6,7 @@ if ! git diff-index --quiet HEAD; then
 	printf 'These files changed when running the command:\n\n'
 
 	git diff --name-only | while read -r n ; do
-		echo "* $n"
+		echo "* \`$n\`"
 	done
 
 	exit 1

--- a/spec/black_box/diff-check_spec.rb
+++ b/spec/black_box/diff-check_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "diff-check" do
       expect(session.run("diff-check")).to have_stdout(<<~SUMMARY
         These files changed when running the command:
 
-        * README
+        * `README`
       SUMMARY
                                                       )
     end


### PR DESCRIPTION
The Actions summary view is formatted as Markdown, as Python uses `__` around files (like `__init__.py`) this looks wrong. If we add (escaped) backticks it looks much nicer.

Based on an idea by @oscargus raised in #4.