### PR TITLE
Switch from diff-index to diff

### DIFF
--- a/bin/diff-check
+++ b/bin/diff-check
@@ -2,7 +2,7 @@
 
 set -e
 
-if ! git diff-index --quiet HEAD; then
+if ! git diff --quiet HEAD; then
 	printf 'These files changed when running the command:\n\n'
 
 	git diff --name-only | while read -r n ; do

--- a/spec/black_box/diff-check_spec.rb
+++ b/spec/black_box/diff-check_spec.rb
@@ -39,11 +39,31 @@ RSpec.describe "diff-check" do
     end
   end
 
+  context "with a non-content file change" do
+    it "emits no output" do
+      session = create_session
+
+      session.run("touch README")
+
+      expect(session.run("diff-check")).to have_no_stdout
+      expect(session.run("diff-check")).to have_no_stderr
+    end
+
+    it "exits with a status of 0" do
+      session = create_session
+
+      session.run("touch README")
+
+      expect(session.run("diff-check")).to be_a_success
+    end
+  end
+
   def create_session
     session = JetBlack::Session.new
 
     session.run("git init")
     session.run("echo 'Hello world' >> README")
+    session.run("touch -d '2 hours ago' README")
     session.run("git add .; git commit -m 'initial commit'")
 
     session


### PR DESCRIPTION
`diff-index`:

    Compare the content and mode of the blobs found in a tree object
    with the corresponding tracked files in the working tree, or with
    the corresponding paths in the index.

Unlike `diff`, which only compares the content. This has the implication (only on Linux) that if you were to recreate a file (or do something like change a file's timestamp with `touch`, as in the test) then a check with `diff-index` would drop us into that code path for there to subsequently be no known files which had changed.

This behaviour came up when testing with Appraisal, which re-creates lockfiles when run, but the content is the same.

https://stackoverflow.com/questions/24197606/whats-the-difference-between-git-diff-and-gif-diff-index https://github.com/thoughtbot/appraisal